### PR TITLE
PLATOPS-1619: upgrade to Play 2.5.19

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,7 +9,7 @@ val playPlugin =
   if (sys.env.get("PLAY_VERSION").exists(_ == "2.6"))
     "com.typesafe.play" % "sbt-plugin" % "2.6.20"
   else
-    "com.typesafe.play" % "sbt-plugin" % "2.5.12"
+    "com.typesafe.play" % "sbt-plugin" % "2.5.19"
 
 addSbtPlugin(playPlugin)
 


### PR DESCRIPTION
We have had to update all the libraries on the platform to use Play 2.5.19 to address a security vulnerability with a version of logback that is included in play (< 2.5.14) which is fixed in play 2.5.19.  